### PR TITLE
add Dir variable for configure partial directory

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -101,6 +101,13 @@ So if you write the following:
 
 It'll be blank. You either have to use `&Person{"John", "Smith"}`, or call `Name2`
 
+## Configure partial directory
+
+    mustache.Dir = "/tmp"
+    mustache.Render("{{> a.mustache}}", map[string]interface{}{})
+
+It will load `/tmp/a.mustache`
+
 ## Supported features
 
 * Variables

--- a/mustache.go
+++ b/mustache.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 )
 
+var Dir = ""
 const defaultOtag = "{{"
 const defaultCtag = "}}"
 
@@ -699,8 +700,10 @@ func ParseString(data string) (*Template, error) {
 }
 
 func parseString(data string, otag string, ctag string, environment environment) (*Template, error) {
-	cwd := os.Getenv("CWD")
-	tmpl := Template{data, otag, ctag, 0, 1, cwd, []interface{}{}, environment}
+	if Dir == "" {
+		Dir = os.Getenv("CWD")
+	}
+	tmpl := Template{data, otag, ctag, 0, 1, Dir, []interface{}{}, environment}
 	err := tmpl.parse()
 
 	if err != nil {


### PR DESCRIPTION
**USAGE**

``` go
mustache.Dir = "/tmp"
mustache.Render("{{> a.mustache}}", map[string]interface{}{})
```

Now, it loads "/tmp/a.mustache"
