### PR TITLE
Fix `golint` and `go vet` issues

### DIFF
--- a/mustache_spec_test.go
+++ b/mustache_spec_test.go
@@ -903,9 +903,8 @@ func TestLambdasSection(t *testing.T) {
 	lambda := func(text string) string {
 		if text == "{{x}}" {
 			return "yes"
-		} else {
-			return "no"
 		}
+		return "no"
 	}
 	template := "<{{#lambda}}{{x}}{{/lambda}}>"
 	expected := "<yes>"

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -20,7 +20,7 @@ type Data struct {
 
 type User struct {
 	Name string
-	Id   int64
+	ID   int64
 }
 
 type settings struct {


### PR DESCRIPTION
- documentation
- idiomatic Go
- remove unreachable code
